### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instalation:
 
     pod 'PMAudioRecorderViewController'
 
-or drop the contents of `AudioNoteRecorderViewController` directory in your XCode project.
+or drop the contents of `AudioNoteRecorderViewController` directory in your Xcode project.
 
 In the code:
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
